### PR TITLE
Fix choices key press with less than 3 options

### DIFF
--- a/code/UI/ChoicePanel.cs
+++ b/code/UI/ChoicePanel.cs
@@ -119,18 +119,12 @@ public class ChoiceModal : Panel
 
 		if (Input.Pressed("reload"))
 			ChoicePanel.Reroll();
-		else if (Input.Pressed("Slot1"))
-			ChoicePanel.OnChoiceMade(_statusTypes[0]);
-        else if (Input.Pressed("Slot2"))
-            ChoicePanel.OnChoiceMade(_statusTypes[1]);
-        else if (Input.Pressed("Slot3"))
-            ChoicePanel.OnChoiceMade(_statusTypes[2]);
-        else if (Input.Pressed("Slot4") && _statusTypes.Count >= 4)
-            ChoicePanel.OnChoiceMade(_statusTypes[3]);
-        else if (Input.Pressed("Slot5") && _statusTypes.Count >= 5)
-            ChoicePanel.OnChoiceMade(_statusTypes[4]);
-        else if (Input.Pressed("Slot6") && _statusTypes.Count >= 6)
-            ChoicePanel.OnChoiceMade(_statusTypes[5]);
+		
+		for (int i = 0; i < _statusTypes.Count; i++)
+		{
+			if (Input.Pressed("Slot" + (i + 1)))
+				ChoicePanel.OnChoiceMade(_statusTypes[i]);
+		}
     }
 }
 


### PR DESCRIPTION
When you get `Strong Faith` upgrade without having `More Choices` upgrade, you'll have less than 3 upgrade choices. This could remove slots 3 and 2. Pressing those slot keys will trigger a waning.

This change fixes the issue by checking key press only on available slots.